### PR TITLE
Fixed issue while saving a module with multilingual rich text box.

### DIFF
--- a/resources/assets/js/multilingual.js
+++ b/resources/assets/js/multilingual.js
@@ -94,7 +94,7 @@
              */
             this.transInputs.each(function(i, inp) {
                 var _inp   = $(inp),
-                    inpUsr = _inp.next(_this.settings.editing ? '.form-control' : '');
+                    inpUsr = $(_inp).parent().find(_this.settings.editing ? '.form-control' : '');
 
                 inpUsr.data("inp", _inp);
                 _inp.data("inpUsr", inpUsr);


### PR DESCRIPTION
Voyager 1.2.3 have an issue with saving/editing multilingual rich text box.

The root cause of this issue is due to the position of DOM element for rich text box inputs. This changes will fix the issue by first targeting the parents of the "_il8n" element and then search for the input field with the class name "form-control".